### PR TITLE
Remove hardcoded log group tags

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,8 +106,8 @@ resource "aws_cloudwatch_log_group" "kinesis" {
   retention_in_days = var.cloudwatch_log_retention
 
   tags = merge(
-    { managed_by_integration = "app-sre/infra" },
-    var.tags
+    var.tags,
+    var.log_group_tags,
   )
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,12 @@ variable "lambda_processing_buffer_size_in_mb" {
   default     = 0.256
 }
 
+variable "log_group_tags" {
+  description = "A map of additional tags to add to all cloudwatch log groups"
+  type        = map(string)
+  default     = {}
+}
+
 variable "log_stream_name" {
   description = "Name of the CloudWatch log stream for Kinesis Firehose CloudWatch log group"
   type        = string


### PR DESCRIPTION
They belonged to the internal testing, now they can be configured.