### PR TITLE
Allow passing plain text hec tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,21 @@ The Lambda function used is the one provided for AWS by Splunk: https://github.c
 ## Usage
 
 * Make sure your local Python interpreter is 3.8.x. This is what is currently targeted by splunk-aws-firehose-flowlogs-processo program.
+* The following example uses KMS to encrypt the HEC token. You can use that or whatever mechanism you have to avoid storing the HEC token in plain text, e.g. a parameter store.
 * Call the module, e.g.:
-```
-module "vpc_flow_logs_to_splunk" {
-  source          = "github.com/app-sre/terraform-aws-vpc-flow-logs-splunk?ref=v<your x.y.z>"
-  vpc_id          = "<your vpc_id>
-  hec_token       = "<KMS encrypted Splunk HEC token>"
-  splunk_endpoint = "<your Splunk endpoint>"
-}
-```
+    ```
+    module "hec_token_kms_secret" {
+      source    = "disney/kinesis-firehose-splunk/aws//modules/kms_secrets"
+      hec_token = "<KMS encrypted Splunk HEC token>"
+    }
+
+    module "vpc_flow_logs_to_splunk" {
+      source          = "github.com/app-sre/terraform-aws-vpc-flow-logs-splunk?ref=v<your x.y.z>"
+      vpc_id          = "<your vpc_id>
+      hec_token       = module.hec_token_kms_secret.hec_token_kms_secret
+      splunk_endpoint = "<your Splunk endpoint>"
+    }
+    ```
 
 ## Credits
 

--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,7 @@ resource "aws_kinesis_firehose_delivery_stream" "vpc_logs_to_splunk" {
 
   splunk_configuration {
     hec_endpoint               = var.splunk_endpoint
-    hec_token                  = module.hec_token_kms_secret.hec_token_kms_secret
+    hec_token                  = var.hec_token
     hec_acknowledgment_timeout = var.hec_acknowledgment_timeout
     hec_endpoint_type          = "Raw"
     retry_duration             = var.firehose_splunk_retry_duration
@@ -98,12 +98,6 @@ resource "aws_s3_bucket_acl" "kinesis_firehose" {
   bucket     = aws_s3_bucket.kinesis_firehose.id
   acl        = "private"
   depends_on = [aws_s3_bucket_ownership_controls.kinesis_firehose]
-}
-
-module "hec_token_kms_secret" {
-  source    = "disney/kinesis-firehose-splunk/aws//modules/kms_secrets"
-  hec_token = var.hec_token
-  version   = "8.1.0" # this cannot be set in a variable, see https://github.com/hashicorp/terraform/issues/28912
 }
 
 resource "aws_cloudwatch_log_group" "kinesis" {

--- a/variables.tf
+++ b/variables.tf
@@ -25,7 +25,6 @@ variable "hec_acknowledgment_timeout" {
 variable "hec_token" {
   description = "Pass the HEC token in plain text (not recommended) or through a parameter store, through a KMS encryption module, etc..."
   type        = string
-  default     = null
   sensitive   = true
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -23,8 +23,10 @@ variable "hec_acknowledgment_timeout" {
 }
 
 variable "hec_token" {
-  description = "KMS encoded Splunk hec token"
+  description = "Pass the HEC token in plain text (not recommended) or through a parameter store, through a KMS encryption module, etc..."
   type        = string
+  default     = null
+  sensitive   = true
 }
 
 variable "kinesis_firehose_buffer" {


### PR DESCRIPTION
It is not recommended to specify directly the token in the module
invocation but use any sort of parameter store.

This is a breaking change as we change the behaviour of the `hec_token`
that moves to be the non-encrypted one to mimic the behaviour of the
firehose configuration.

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>