### PR TITLE
Remove the need for Lambda processing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "splunk-aws-firehose-flowlogs-processor"]
-	path = splunk-aws-firehose-flowlogs-processor
-	url = https://github.com/splunk/splunk-aws-firehose-flowlogs-processor

--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # Send VPC Flow logs to Splunk via Kinesis Firehose
 
-This module configures a Kinesis Firehose, sets up a subscription for a desired CloudWatch Log Group to the Firehose, and sends the log data to Splunk. A Lambda function is required to transform the VPC Log data to a format compatible with Splunk. This module takes care of configuring this Lambda function.
+This module configures a Kinesis Firehose, sets up a subscription for a desired CloudWatch Log Group to the Firehose, and sends the log data to Splunk.
 
-The Lambda function used is the one provided for AWS by Splunk: https://github.com/splunk/splunk-aws-firehose-flowlogs-processor
+According to [AWS Big Data Blog](https://aws.amazon.com/blogs/big-data/ingest-vpc-flow-logs-into-splunk-using-amazon-kinesis-data-firehose/), a Lambda is no longer required to transform the VPC flow logs according to the 7.3.0 version in Splunk AWS Add-on, hence this module does not contain any Lambda processing any more. If you need to send data to a Splunk system with an older Add-on, please take a look to v0.1.0 of this module.
 
 ## Usage
 
-* Make sure your local Python interpreter is 3.8.x. This is what is currently targeted by splunk-aws-firehose-flowlogs-processo program.
 * The following example uses KMS to encrypt the HEC token. You can use that or whatever mechanism you have to avoid storing the HEC token in plain text, e.g. a parameter store.
 * Call the module, e.g.:
     ```
@@ -23,6 +22,8 @@ The Lambda function used is the one provided for AWS by Splunk: https://github.c
     }
     ```
 
+
+
 ## Credits
 
-A good deal of inspiration on how to work with Firehose and Lambdas provided by a similar module: [Send CloudWatch Logs to Splunk via Kinesis Firehose](https://github.com/disney/terraform-aws-kinesis-firehose-splunk)
+A good deal of inspiration on how to work with Firehose provided by a similar module: [Send CloudWatch Logs to Splunk via Kinesis Firehose](https://github.com/disney/terraform-aws-kinesis-firehose-splunk)

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,7 @@ resource "aws_flow_log" "vpc" {
   max_aggregation_interval = var.flow_log_max_aggregation_interval
 }
 
-# endpoint type is set to Raw since we're using the Splunk provider lambda to send data.
+# Endpoint type is set to Raw
 # See https://aws.amazon.com/blogs/big-data/ingest-vpc-flow-logs-into-splunk-using-amazon-kinesis-data-firehose/
 resource "aws_kinesis_firehose_delivery_stream" "vpc_logs_to_splunk" {
   name        = "${local.name}-vpc-logs-to-splunk"
@@ -32,34 +32,6 @@ resource "aws_kinesis_firehose_delivery_stream" "vpc_logs_to_splunk" {
       buffering_size     = var.kinesis_firehose_buffer
       buffering_interval = var.kinesis_firehose_buffer_interval
       compression_format = var.s3_compression_format
-    }
-
-    processing_configuration {
-      enabled = true
-
-      processors {
-        type = "Lambda"
-
-        parameters {
-          parameter_name  = "LambdaArn"
-          parameter_value = "${aws_lambda_function.splunk_firehose_flowlogs_processor.arn}:$LATEST"
-        }
-
-        parameters {
-          parameter_name  = "RoleArn"
-          parameter_value = aws_iam_role.kinesis_firehose.arn
-        }
-
-        parameters {
-          parameter_name  = "BufferSizeInMBs"
-          parameter_value = var.lambda_processing_buffer_size_in_mb
-        }
-
-        parameters {
-          parameter_name  = "BufferIntervalInSeconds"
-          parameter_value = var.lambda_processing_buffer_interval_in_seconds
-        }
-      }
     }
 
     cloudwatch_logging_options {
@@ -115,82 +87,6 @@ resource "aws_cloudwatch_log_stream" "kinesis" {
   log_group_name = aws_cloudwatch_log_group.kinesis.name
 }
 
-resource "aws_iam_role" "vpc_flow_logs_to_splunk_kinesis_firehose_lambda" {
-  name        = "${local.name}-vpc-flow-logs-to-splunk-firehose-lambda"
-  description = "Role for Lambda function to transform VPC Flow Logs into Splunk compatible format"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Action = "sts:AssumeRole"
-        Effect = "Allow"
-        Principal = {
-          Service = "lambda.amazonaws.com"
-        }
-      },
-    ]
-  })
-
-  inline_policy {
-    name = "${local.name}-vpc-flow-logs-to-splunk-firehose-lambda"
-
-    policy = jsonencode({
-      Version = "2012-10-17"
-      Statement = [
-        {
-          Effect = "Allow",
-          Action = [
-            "logs:CreateLogGroup",
-            "logs:CreateLogStream",
-            "logs:PutLogEvents"
-          ],
-          Resource = ["*"]
-        },
-      ]
-    })
-  }
-
-  tags = merge(
-    { Name = "${local.name}-vpc-flow-logs-to-splunk-kinesis-firehose-lambda" },
-    var.tags,
-  )
-}
-
-# Prepare Lambda package (https://github.com/hashicorp/terraform/issues/8344#issuecomment-345807204)
-resource "null_resource" "pip" {
-  triggers = {
-    app          = "${base64sha256(file("${path.module}/splunk-aws-firehose-flowlogs-processor/SplunkFirehoseFlowlogsProcessor/app.py"))}"
-    requirements = "${base64sha256(file("${path.module}/splunk-aws-firehose-flowlogs-processor/SplunkFirehoseFlowlogsProcessor/requirements.txt"))}"
-  }
-
-  provisioner "local-exec" {
-    command = "pip install --no-compile --no-cache-dir -r ${path.module}/splunk-aws-firehose-flowlogs-processor/SplunkFirehoseFlowlogsProcessor/requirements.txt -t ${path.module}/splunk-aws-firehose-flowlogs-processor/SplunkFirehoseFlowlogsProcessor/lib"
-  }
-}
-
-data "archive_file" "lambda_zip" {
-  type        = "zip"
-  source_dir  = "${path.module}/splunk-aws-firehose-flowlogs-processor/SplunkFirehoseFlowlogsProcessor/"
-  output_path = "${path.module}/splunk-aws-firehose-flowlogs-processor/SplunkFirehoseFlowlogsProcessor.zip"
-  depends_on  = [null_resource.pip]
-}
-
-resource "aws_lambda_function" "splunk_firehose_flowlogs_processor" {
-  filename         = "${path.module}/splunk-aws-firehose-flowlogs-processor/SplunkFirehoseFlowlogsProcessor.zip"
-  function_name    = "splunk-firehose-flowlogs-processor"
-  role             = aws_iam_role.vpc_flow_logs_to_splunk_kinesis_firehose_lambda.arn
-  handler          = "app.lambda_handler"
-  runtime          = "python3.8"
-  source_code_hash = data.archive_file.lambda_zip.output_base64sha256
-  timeout          = var.lambda_function_timeout
-
-  tags = merge(
-    { Name = "splunk-firehose-flowlogs-processor" },
-    var.tags,
-  )
-}
-
 resource "aws_iam_role" "kinesis_firehose" {
   name        = "${local.name}-vpc-flow-logs-to-splunk-kinesis-firehose"
   description = "IAM Role for Kinesis Firehose to send ${local.name} vpc flow logs to splunk"
@@ -227,16 +123,6 @@ resource "aws_iam_role" "kinesis_firehose" {
           Resource = [
             aws_s3_bucket.kinesis_firehose.arn,
             "${aws_s3_bucket.kinesis_firehose.arn}/*",
-          ]
-        },
-        {
-          Effect = "Allow",
-          Action = [
-            "lambda:InvokeFunction",
-            "lambda:GetFunctionConfiguration",
-          ],
-          Resource = [
-            "${aws_lambda_function.splunk_firehose_flowlogs_processor.arn}:$LATEST"
           ]
         },
       ]


### PR DESCRIPTION
From version 7.3.0 of the Splunk AWS Add-on, lambda processing is no longer necessary.

See https://aws.amazon.com/blogs/big-data/ingest-vpc-flow-logs-into-splunk-using-amazon-kinesis-data-firehose/