### PR TITLE
Allow module consumers to pass `log_format`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,7 @@ resource "aws_flow_log" "vpc" {
   traffic_type             = "ALL"
   vpc_id                   = var.vpc_id
   max_aggregation_interval = var.flow_log_max_aggregation_interval
+  log_format               = var.log_format
 }
 
 # Endpoint type is set to Raw

--- a/variables.tf
+++ b/variables.tf
@@ -119,3 +119,9 @@ variable "vpc_id" {
     error_message = "The vpc_id cannot be longer than 21 characters."
   }
 }
+
+variable "log_format" {
+  description = "(Optional) The fields to include in the flow log record."
+  type        = string
+  default     = "$${version} $${account-id} $${interface-id} $${srcaddr} $${dstaddr} $${srcport} $${dstport} $${protocol} $${packets} $${bytes} $${start} $${end} $${action} $${log-status}"
+}


### PR DESCRIPTION
Fields that can be passed are listed here:
https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html