### PR TITLE
Make the AWS provider requirement less restrictive

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0.0, < 6.0.0"
+      version = ">= 5.0.0"
     }
   }
 }


### PR DESCRIPTION
This become a problem when in the same Terraform
plan other modules require a version 6 of the AWS
provider.