### PR TITLE
Add HTTP endpoint destination support for Kinesis Firehose

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ v0.1.0 of this module.
 
 [AWS Big Data Blog URL]: https://aws.amazon.com/blogs/big-data/ingest-vpc-flow-logs-into-splunk-using-amazon-kinesis-data-firehose
 
+## Destination Types
+
+This module supports two destination types for sending data to Splunk:
+
+* **splunk** (default): Uses the native Splunk destination with HEC Raw endpoint
+* **http_endpoint**: Uses the generic HTTP endpoint destination, useful when sending data through a proxy or load balancer
+
+Both destination types use the same `splunk_endpoint` and `hec_token` variables.
+
 ## Usage
 
 * Example for handling multiple VPCs:
@@ -35,6 +44,17 @@ v0.1.0 of this module.
       hec_token       = var.hec_token
       splunk_endpoint = "<your Splunk endpoint>"
       source          = "github.com/app-sre/terraform-aws-vpc-flow-logs-splunk?<x.y.z>"
+    }
+    ```
+
+* Example using HTTP endpoint destination:
+    ```
+    module "vpc_flow_logs_to_splunk" {
+      source           = "github.com/app-sre/terraform-aws-vpc-flow-logs-splunk?ref=v<x.y.z>"
+      vpc_id           = "<your vpc_id>"
+      hec_token        = var.hec_token
+      splunk_endpoint  = "<your Splunk endpoint>"
+      destination_type = "http_endpoint"
     }
     ```
 **Notice:** Do *not* keep the HEC token as clear text in the configuration!

--- a/main.tf
+++ b/main.tf
@@ -24,9 +24,15 @@ module "vpc_logs_to_splunk" {
   kinesis_firehose_buffer_interval = var.kinesis_firehose_buffer_interval
   log_group_tags                   = var.log_group_tags
   log_stream_name                  = var.log_stream_name
-  s3_backup_mode                   = var.s3_backup_mode
+  splunk_s3_backup_mode            = var.splunk_s3_backup_mode
+  http_endpoint_s3_backup_mode     = var.http_endpoint_s3_backup_mode
   s3_compression_format            = var.s3_compression_format
   s3_prefix                        = var.s3_prefix
   splunk_endpoint                  = var.splunk_endpoint
   tags                             = var.tags
+  destination_type                 = var.destination_type
+  http_endpoint_name               = var.http_endpoint_name
+  http_endpoint_retry_duration     = var.http_endpoint_retry_duration
+  http_endpoint_content_encoding   = var.http_endpoint_content_encoding
+  http_endpoint_common_attributes  = var.http_endpoint_common_attributes
 }

--- a/modules/splunk-firehose-connection/main.tf
+++ b/modules/splunk-firehose-connection/main.tf
@@ -1,6 +1,7 @@
 # Endpoint type is set to Raw
 # See https://aws.amazon.com/blogs/big-data/ingest-vpc-flow-logs-into-splunk-using-amazon-kinesis-data-firehose/
 resource "aws_kinesis_firehose_delivery_stream" "logs_to_splunk" {
+  count       = var.destination_type == "splunk" ? 1 : 0
   name        = var.name
   destination = "splunk"
 
@@ -10,7 +11,59 @@ resource "aws_kinesis_firehose_delivery_stream" "logs_to_splunk" {
     hec_acknowledgment_timeout = var.hec_acknowledgment_timeout
     hec_endpoint_type          = "Raw"
     retry_duration             = var.firehose_splunk_retry_duration
-    s3_backup_mode             = var.s3_backup_mode
+    s3_backup_mode             = var.splunk_s3_backup_mode
+
+    s3_configuration {
+      role_arn           = aws_iam_role.kinesis_firehose.arn
+      bucket_arn         = aws_s3_bucket.kinesis_firehose.arn
+      prefix             = var.s3_prefix
+      buffering_size     = var.kinesis_firehose_buffer
+      buffering_interval = var.kinesis_firehose_buffer_interval
+      compression_format = var.s3_compression_format
+    }
+
+    cloudwatch_logging_options {
+      enabled         = true
+      log_group_name  = aws_cloudwatch_log_group.kinesis.name
+      log_stream_name = aws_cloudwatch_log_stream.kinesis.name
+    }
+  }
+
+  tags = merge(
+    {
+      Name               = var.name
+      LogDeliveryEnabled = "true"
+    },
+    var.tags,
+  )
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "logs_to_http_endpoint" {
+  count       = var.destination_type == "http_endpoint" ? 1 : 0
+  name        = "${var.name}-via-http-endpoint"
+  destination = "http_endpoint"
+
+  http_endpoint_configuration {
+    url                = var.splunk_endpoint
+    name               = var.http_endpoint_name
+    access_key         = var.hec_token
+    s3_backup_mode     = var.http_endpoint_s3_backup_mode
+    buffering_size     = var.kinesis_firehose_buffer
+    buffering_interval = var.kinesis_firehose_buffer_interval
+    retry_duration     = var.http_endpoint_retry_duration
+    role_arn           = aws_iam_role.kinesis_firehose.arn
+
+    request_configuration {
+      content_encoding = var.http_endpoint_content_encoding
+
+      dynamic "common_attributes" {
+        for_each = var.http_endpoint_common_attributes
+        content {
+          name  = common_attributes.value.name
+          value = common_attributes.value.value
+        }
+      }
+    }
 
     s3_configuration {
       role_arn           = aws_iam_role.kinesis_firehose.arn

--- a/modules/splunk-firehose-connection/outputs.tf
+++ b/modules/splunk-firehose-connection/outputs.tf
@@ -1,3 +1,3 @@
 output "log_destination" {
-  value = aws_kinesis_firehose_delivery_stream.logs_to_splunk.arn
+  value = var.destination_type == "splunk" ? aws_kinesis_firehose_delivery_stream.logs_to_splunk[0].arn : aws_kinesis_firehose_delivery_stream.logs_to_http_endpoint[0].arn
 }

--- a/modules/splunk-firehose-connection/variables.tf
+++ b/modules/splunk-firehose-connection/variables.tf
@@ -22,7 +22,7 @@ variable "hec_acknowledgment_timeout" {
 }
 
 variable "hec_token" {
-  description = "Pass the HEC token in plain text (not recommended) or through a parameter store, through a KMS encryption module, etc..."
+  description = "Splunk HEC token. Pass it in plain text (not recommended) or through a parameter store, through a KMS encryption module, etc."
   type        = string
   sensitive   = true
 }
@@ -56,10 +56,16 @@ variable "name" {
   type        = string
 }
 
-variable "s3_backup_mode" {
-  description = "Defines how documents should be delivered to Amazon S3."
+variable "splunk_s3_backup_mode" {
+  description = "S3 backup mode for Splunk destination: FailedEventsOnly or AllEvents"
   type        = string
   default     = "FailedEventsOnly"
+}
+
+variable "http_endpoint_s3_backup_mode" {
+  description = "S3 backup mode for HTTP endpoint destination: FailedDataOnly or AllData"
+  type        = string
+  default     = "FailedDataOnly"
 }
 variable "s3_compression_format" {
   description = "The compression format for what the Kinesis Firehose puts in the s3 bucket"
@@ -74,7 +80,7 @@ variable "s3_prefix" {
 }
 
 variable "splunk_endpoint" {
-  description = "Splunk endpoint"
+  description = "Splunk endpoint URL."
   type        = string
 }
 
@@ -82,4 +88,42 @@ variable "tags" {
   description = "A map of tags to add to all resources"
   type        = map(string)
   default     = {}
+}
+
+variable "destination_type" {
+  description = "Firehose destination type: splunk or http_endpoint"
+  type        = string
+  default     = "splunk"
+
+  validation {
+    condition     = contains(["splunk", "http_endpoint"], var.destination_type)
+    error_message = "destination_type must be 'splunk' or 'http_endpoint'"
+  }
+}
+
+variable "http_endpoint_name" {
+  description = "HTTP endpoint name"
+  type        = string
+  default     = "Splunk HTTP Endpoint"
+}
+
+variable "http_endpoint_retry_duration" {
+  description = "Total time in seconds for retries (0-7200)"
+  type        = number
+  default     = 300
+}
+
+variable "http_endpoint_content_encoding" {
+  description = "Content encoding: GZIP or NONE"
+  type        = string
+  default     = "GZIP"
+}
+
+variable "http_endpoint_common_attributes" {
+  description = "List of common attributes (name/value pairs) sent with each request"
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -23,7 +23,7 @@ variable "hec_acknowledgment_timeout" {
 }
 
 variable "hec_token" {
-  description = "Pass the HEC token in plain text (not recommended) or through a parameter store, through a KMS encryption module, etc..."
+  description = "Splunk HEC token. Pass it in plain text (not recommended) or through a parameter store, through a KMS encryption module, etc."
   type        = string
   sensitive   = true
 }
@@ -52,11 +52,18 @@ variable "log_stream_name" {
   default     = "SplunkDelivery"
 }
 
-variable "s3_backup_mode" {
-  description = "Defines how documents should be delivered to Amazon S3."
+variable "splunk_s3_backup_mode" {
+  description = "S3 backup mode for Splunk destination: FailedEventsOnly or AllEvents"
   type        = string
   default     = "FailedEventsOnly"
 }
+
+variable "http_endpoint_s3_backup_mode" {
+  description = "S3 backup mode for HTTP endpoint destination: FailedDataOnly or AllData"
+  type        = string
+  default     = "FailedDataOnly"
+}
+
 variable "s3_compression_format" {
   description = "The compression format for what the Kinesis Firehose puts in the s3 bucket"
   type        = string
@@ -70,7 +77,7 @@ variable "s3_prefix" {
 }
 
 variable "splunk_endpoint" {
-  description = "Splunk endpoint"
+  description = "Splunk endpoint URL."
   type        = string
 }
 
@@ -106,4 +113,42 @@ variable "log_format" {
   description = "(Optional) The fields to include in the flow log record."
   type        = string
   default     = "$${version} $${account-id} $${interface-id} $${srcaddr} $${dstaddr} $${srcport} $${dstport} $${protocol} $${packets} $${bytes} $${start} $${end} $${action} $${log-status}"
+}
+
+variable "destination_type" {
+  description = "Firehose destination type: splunk or http_endpoint"
+  type        = string
+  default     = "splunk"
+
+  validation {
+    condition     = contains(["splunk", "http_endpoint"], var.destination_type)
+    error_message = "destination_type must be 'splunk' or 'http_endpoint'"
+  }
+}
+
+variable "http_endpoint_name" {
+  description = "HTTP endpoint name"
+  type        = string
+  default     = "Splunk HTTP Endpoint"
+}
+
+variable "http_endpoint_retry_duration" {
+  description = "Total time in seconds for retries (0-7200)"
+  type        = number
+  default     = 300
+}
+
+variable "http_endpoint_content_encoding" {
+  description = "Content encoding: GZIP or NONE"
+  type        = string
+  default     = "GZIP"
+}
+
+variable "http_endpoint_common_attributes" {
+  description = "List of common attributes (name/value pairs) sent with each request"
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = []
 }


### PR DESCRIPTION
Add HTTP endpoint destination support for Kinesis Firehose

Extend the module to support both 'splunk' and 'http_endpoint'
destination types for the Kinesis Firehose delivery stream, providing
flexibility to send VPC Flow Logs to any HTTP endpoint in addition
to Splunk HEC.

- Add http_endpoint destination type as alternative to splunk destination
- Reuse splunk_endpoint and hec_token variables for HTTP endpoint config
- Update README with destination types documentation

BREAKING CHANGES:
- Renamed s3_backup_mode to splunk_s3_backup_mode

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>

Assisted-by: Claude Opus 4.5 <noreply@anthropic.co