### PR TITLE
Replace deprecated inline_policy with aws_iam_role_policy resource

### DIFF
--- a/modules/splunk-firehose-connection/main.tf
+++ b/modules/splunk-firehose-connection/main.tf
@@ -144,33 +144,33 @@ resource "aws_iam_role" "kinesis_firehose" {
     ]
   })
 
-  inline_policy {
-    name = var.name
-
-    policy = jsonencode({
-      Version = "2012-10-17"
-      Statement = [
-        {
-          Effect = "Allow",
-          Action = [
-            "s3:AbortMultipartUpload",
-            "s3:GetBucketLocation",
-            "s3:GetObject",
-            "s3:ListBucket",
-            "s3:ListBucketMultipartUploads",
-            "s3:PutObject",
-          ],
-          Resource = [
-            aws_s3_bucket.kinesis_firehose.arn,
-            "${aws_s3_bucket.kinesis_firehose.arn}/*",
-          ]
-        },
-      ]
-    })
-  }
-
   tags = merge(
     { Name = var.name },
     var.tags,
   )
+}
+
+resource "aws_iam_role_policy" "kinesis_firehose" {
+  name = var.name
+  role = aws_iam_role.kinesis_firehose.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "s3:AbortMultipartUpload",
+          "s3:GetBucketLocation",
+          "s3:GetObject",
+          "s3:ListBucket",
+          "s3:ListBucketMultipartUploads",
+          "s3:PutObject",
+        ],
+        Resource = [
+          aws_s3_bucket.kinesis_firehose.arn,
+          "${aws_s3_bucket.kinesis_firehose.arn}/*",
+        ]
+      },
+    ]
+  })
 }


### PR DESCRIPTION
The inline_policy argument on aws_iam_role is deprecated in recent versions of the AWS provider. Extract the inline policy into a standalone aws_iam_role_policy resource with identical permissions.

Closes #23


Made-with: Cursor